### PR TITLE
Fix gas price validation in proxied execution

### DIFF
--- a/contracts/ChainWalletMaster.sol
+++ b/contracts/ChainWalletMaster.sol
@@ -294,7 +294,7 @@ contract ChainWalletMaster is
     ) {
         uint256 gasLimit = gasleft() + 36000;
         require(gasLimit - 36000 <= input.gasLimit, "PROXY_GAS_LIMIT_TOO_HIGH");
-        require(input.gasPrice <= tx.gasprice, "PROXY_GAS_PRICE_TOO_HIGH");
+        require(input.gasPrice == tx.gasprice, "WRONG_PROXY_GAS_PRICE");
         require(!_proxyTransactions[transactionId].processed, "TRANSACTION_ALREADY_PROCESSED");
         require(
             _proxyTransactions[transactionId].addressHash == keccak256(abi.encode(input.agentAddress)),


### PR DESCRIPTION
## Motivation

Gas price in proxied execution is currently allowed to be lower than the amount set by the user. This creates the opportunity for a malicious proxy to attempt executions that end up delayed beyond the user's expectations. This is minor because there is no incentive for doing this as it reduces the amount the proxy earns for successful execution. However, it can be a potential problem in situations where the network is handling more activity than it has the capacity to immediately execute, causing more delay than is necessary for some transactions.

## Implementation

The gas price validation is updated to require an exact match with the gas price supplied by the user during transaction creation.